### PR TITLE
Udp fix

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,104 @@
+---
+Language: Cpp
+# BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     90
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeCategories:
+  - Regex:           '^"(gnuradio)/'
+    Priority:        1
+  - Regex:           '^<(gnuradio)/'
+    Priority:        2
+  - Regex:           '^<(boost)/'
+    Priority:        98
+  - Regex:           '^<[a-z]*>$'
+    Priority:        99
+  - Regex:           '^".*"$'
+    Priority:        0
+  - Regex:           '.*'
+    Priority:        10
+
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never

--- a/gr-CyberRadio/include/CyberRadio/vita_udp_rx.h
+++ b/gr-CyberRadio/include/CyberRadio/vita_udp_rx.h
@@ -36,9 +36,10 @@ namespace CyberRadio {
 
 // Note: the recommendation from GNU Radio developers is the sources and sinks should
 // always inherit from gr::block, not one of the more derived types
-class CYBERRADIO_API vita_udp_rx : virtual public gr::block
+class CYBERRADIO_API vita_udp_rx : public gr::block
 {
 public:
+    using BaseBlock = gr::block;
     using sptr = boost::shared_ptr<vita_udp_rx>;
 
     // Because this class takes a number of optional configuration items, and because the
@@ -72,11 +73,7 @@ public:
     bool stop() override = 0;
 
 protected:
-    // To avoid a subtle bug, declare a protected ctor here to ensure the proper base
-    // class ctor is invoked
-    vita_udp_rx(std::string const& name,
-                gr::io_signature::sptr input,
-                gr::io_signature::sptr output);
+    using BaseBlock::block;
 };
 
 } // namespace CyberRadio

--- a/gr-CyberRadio/include/CyberRadio/vita_udp_rx.h
+++ b/gr-CyberRadio/include/CyberRadio/vita_udp_rx.h
@@ -1,17 +1,17 @@
-/* -*- c++ -*- */
-/* 
+// -*- c++ -*-
+/*
  * Copyright 2017 <+YOU OR YOUR COMPANY+>.
- * 
+ *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this software; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -22,50 +22,60 @@
 #ifndef INCLUDED_CYBERRADIO_VITA_UDP_RX_H
 #define INCLUDED_CYBERRADIO_VITA_UDP_RX_H
 
+#include <gnuradio/block.h>
 #include <CyberRadio/api.h>
-#include <gnuradio/sync_interpolator.h>
-#include <gnuradio/sync_block.h>
 
 namespace gr {
-  namespace CyberRadio {
+namespace CyberRadio {
 
-    /*!
-     * \brief <+description of block+>
-     * \ingroup CyberRadio
-     *
-     */
-    class CYBERRADIO_API vita_udp_rx : virtual public gr::sync_interpolator
-    {
-     public:
-      typedef boost::shared_ptr<vita_udp_rx> sptr;
+/*!
+ * \brief <+description of block+>
+ * \ingroup CyberRadio
+ *
+ */
 
-      /*!
-       * \brief Return a shared_ptr to a new instance of vita_udp_rx::vita_udp_rx.
-       *
-       * To avoid accidental use of raw pointers, vita_udp_rx::vita_udp_rx's
-       * constructor is in a private implementation
-       * class. vita_udp_rx::vita_udp_rx::make is the public interface for
-       * creating new instances.
-       */
-      static sptr make(const std::string &src_ip,
-                        unsigned short port,
-                        unsigned int header_byte_offset,
-                        int samples_per_packet,
-                        int bytes_per_packet,
-                        bool swap_bytes,
-                        bool swap_iq,
-                        bool tag_packets,
-                        bool vector_output,
-                        bool uses_v49_1 = true,
-                        bool narrowband = false,
-                        bool debug = false);
-    
-      virtual bool start() = 0;
-      virtual bool stop() = 0;
+// Note: the recommendation from GNU Radio developers is the sources and sinks should
+// always inherit from gr::block, not one of the more derived types
+class CYBERRADIO_API vita_udp_rx : virtual public gr::block
+{
+public:
+    using sptr = boost::shared_ptr<vita_udp_rx>;
 
+    // Because this class takes a number of optional configuration items, and because the
+    // signature changed in a way that could lead to undiagnosed errors, collapse all the
+    // configuration items to a structure and pass that
+    struct Cfg {
+        std::string src_ip;          ///< source IP address to bind to
+        short port;                  ///< source port to bind to
+        unsigned header_byte_offset; ///< number of bytes in the V49 header
+        int samples_per_packet;      ///< number of samples in a packet
+        int bytes_per_packet;        ///< total size of the V49 packet
+        bool swap_bytes;             ///< if the packet should be byteswapped
+        bool swap_iq;                ///< change from IQ to QI (or from QI to IQ)
+        bool tag_packets;            ///< add GR tags to the stream
+        bool uses_v49_1 = true;      ///< VITA 49.1 (VRLP and VEND headers)
+        bool narrowband = false;     ///< if using a narrowband DDC
+        bool debug = false;          ///< output extra debug info
     };
 
-  } // namespace CyberRadio
+    /*!
+     * \brief Return a shared_ptr to a new instance of vita_udp_rx::vita_udp_rx.
+     *
+     * To avoid accidental use of raw pointers, vita_udp_rx::vita_udp_rx's
+     * constructor is in a private implementation class. vita_udp_rx::vita_udp_rx::make
+     * is the public interface for creating new instances.
+     */
+    static auto make(Cfg const& cfg) -> sptr;
+
+    // these are already virtual ... do we need the pure virtual?
+    bool start() override = 0;
+    bool stop() override = 0;
+
+protected:
+    using gr::block::block; // "inherit" base class ctor
+};
+
+} // namespace CyberRadio
 } // namespace gr
 
-#endif /* INCLUDED_CYBERRADIO_VITA_UDP_RX_H */
+#endif // INCLUDED_CYBERRADIO_VITA_UDP_RX_H

--- a/gr-CyberRadio/include/CyberRadio/vita_udp_rx.h
+++ b/gr-CyberRadio/include/CyberRadio/vita_udp_rx.h
@@ -72,7 +72,11 @@ public:
     bool stop() override = 0;
 
 protected:
-    using gr::block::block; // "inherit" base class ctor
+    // To avoid a subtle bug, declare a protected ctor here to ensure the proper base
+    // class ctor is invoked
+    vita_udp_rx(std::string const& name,
+                gr::io_signature::sptr input,
+                gr::io_signature::sptr output);
 };
 
 } // namespace CyberRadio

--- a/gr-CyberRadio/lib/vita_udp_rx_impl.cc
+++ b/gr-CyberRadio/lib/vita_udp_rx_impl.cc
@@ -111,6 +111,13 @@ auto vita_udp_rx::make(Cfg const& cfg) -> sptr
     return gnuradio::get_initial_sptr(new vita_udp_rx_impl(cfg));
 }
 
+vita_udp_rx::vita_udp_rx(std::string const& name,
+                         gr::io_signature::sptr input,
+                         gr::io_signature::sptr output)
+    : gr::block(name, input, output)
+{
+}
+
 auto vita_udp_rx_impl::receive_packet() -> bool
 {
     auto success = false;
@@ -421,9 +428,9 @@ vita_udp_rx_impl::vita_udp_rx_impl(Cfg const& cfg)
 
     // Create input port
     message_port_register_in(control_port);
-    set_msg_handler(control_port, boost::bind(&vita_udp_rx_impl::rxControlMsg, this, _1));
+    set_msg_handler(control_port, [this](pmt::pmt_t const& msg) { rxControlMsg(msg); });
 
-    // Create output ports
+    // Create output port
     message_port_register_out(status_port);
 }
 

--- a/gr-CyberRadio/lib/vita_udp_rx_impl.cc
+++ b/gr-CyberRadio/lib/vita_udp_rx_impl.cc
@@ -116,13 +116,6 @@ auto vita_udp_rx::make(Cfg const& cfg) -> sptr
     return gnuradio::get_initial_sptr(new vita_udp_rx_impl(cfg));
 }
 
-vita_udp_rx::vita_udp_rx(std::string const& name,
-                         gr::io_signature::sptr input,
-                         gr::io_signature::sptr output)
-    : gr::block(name, input, output)
-{
-}
-
 auto vita_udp_rx_impl::receive_packet() -> bool
 {
     auto success = false;
@@ -426,8 +419,11 @@ vita_udp_rx_impl::vita_udp_rx_impl(Cfg const& cfg)
       d_debug(cfg.debug),
       d_first_packet(true),
       d_packetCounter(0),
-      d_buffer(cfg.bytes_per_packet)
+      d_buffer()
 {
+    // pre-allocate the memory
+    d_buffer.reserve(cfg.bytes_per_packet);
+
     // don't call work() until there is enough space for a whole packet
     set_output_multiple(d_samples_per_packet);
 

--- a/gr-CyberRadio/lib/vita_udp_rx_impl.cc
+++ b/gr-CyberRadio/lib/vita_udp_rx_impl.cc
@@ -1,4 +1,4 @@
-/* -*- c++ -*- */
+// -*- c++ -*-
 /*
  * Copyright 2017 <+YOU OR YOUR COMPANY+>.
  *
@@ -24,380 +24,555 @@
 
 #include "vita_udp_rx_impl.h"
 #include <gnuradio/io_signature.h>
+#include <arpa/inet.h>
+#include <sys/socket.h> // consider boost::asio?
+#include <volk/volk.h>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
+
+namespace {
+auto const control_port = pmt::mp("control");
+auto const status_port = pmt::mp("status");
+
+// V49 Struct Info
+struct V49_308_Header {
+    char p;
+    char l;
+    char r;
+    char v;
+    unsigned int frame_info;
+    unsigned int packet_info;
+    unsigned int stream_id;
+    unsigned int class_id_1;
+    unsigned int class_id_2;
+    unsigned int int_timestamp;
+    unsigned int frac_timestamp_msw;
+    unsigned int frac_timestamp_lsw;
+};
+
+// VITA 49 VRT IF data packet header, no class ID
+// (used without external framing on NDR354/364)
+struct V49_No491_Header {
+    unsigned int packet_info;
+    unsigned int stream_id;
+    unsigned int int_timestamp;
+    unsigned int frac_timestamp_msw;
+    unsigned int frac_timestamp_lsw;
+};
+
+struct V49_0_Header {
+    uint32_t packet_info;
+    uint32_t stream_id;
+    uint32_t class_0;
+    uint32_t class_1;
+    uint32_t int_timestamp;
+    uint32_t frac_timestamp_msw;
+    uint32_t frac_timestamp_lsw;
+    uint32_t ddc_0;
+    uint32_t ddc_1;
+    uint32_t ddc_2;
+    uint32_t ddc_3;
+    uint32_t ddc_4;
+};
+
+std::map<int, float> ndr358_551_ddc_map = {
+    { 0, 0.25e3 }, { 1, 0.5e3 },  { 2, 1.0e3 },  { 3, 2.0e3 },   { 4, 4.0e3 },
+    { 5, 8.0e3 },  { 6, 16e3 },   { 7, 32e3 },   { 8, 64e3 },    { 9, 128e3 },
+    { 10, 200e3 }, { 11, 256e3 }, { 12, 400e3 }, { 13, 1.28e6 }, { 14, 3.2e6 },
+    { 15, 4e6 },   { 16, 2e6 },   { 32, 8e6 },   { 33, 8e6 },    { 34, 16e6 },
+    { 35, 16e6 },  { 36, 16e6 },  { 37, 32e6 },  { 38, 32e6 },   { 39, 64e6 },
+    { 40, 128e6 }
+};
+
+void raise_error(std::string tag, int sock)
+{
+    // see http://www.club.cc.cmu.edu/~cmccabe/blog_strerror.html for problems with
+    // strerror
+    tag.append(": ");
+    if (errno < sys_nerr)
+        tag.append(sys_errlist[errno]);
+    else
+        tag.append("Unknown error ").append(std::to_string(errno));
+
+    // wait until after strerror to avoid polluting errno
+    ::close(sock); // this might fail if the sock wasn't open
+
+    throw std::runtime_error(tag);
+}
+
+} // namespace
 
 namespace gr {
 namespace CyberRadio {
 
-vita_udp_rx::sptr
-vita_udp_rx::make(const std::string &src_ip, unsigned short port,
-                  unsigned int header_byte_offset, int samples_per_packet,
-                  int bytes_per_packet, bool swap_bytes, bool swap_iq,
-                  bool tag_packets, bool vector_output, bool uses_v491,
-                  bool narrowband, bool debug) {
-  return gnuradio::get_initial_sptr(
-      new vita_udp_rx_impl(src_ip, port, header_byte_offset, samples_per_packet,
-                           bytes_per_packet, swap_bytes, swap_iq, tag_packets,
-                           vector_output, uses_v491, narrowband, debug));
+auto vita_udp_rx::make(Cfg const& cfg) -> sptr
+{
+    return gnuradio::get_initial_sptr(new vita_udp_rx_impl(cfg));
+}
+
+auto vita_udp_rx_impl::receive_packet() -> bool
+{
+    auto success = false;
+
+    // If this is called, it's because we need to fill the buffer. Make sure it is sized,
+    // then fill it
+    d_buffer.resize(d_bytes_per_packet);
+
+    auto nbytesRx = recv(d_sock, d_buffer.data(), d_buffer.size(), 0);
+    if (nbytesRx == d_buffer.size()) {
+
+        // Byte-swap the header if needed so we can read it
+        if (d_swap_bytes) {
+            volk_32u_byteswap(reinterpret_cast<uint32_t*>(d_buffer.data()),
+                              d_header_byte_offset / 4);
+        }
+
+        success = true;
+    } else {
+        std::cerr
+            << "gr::CyberRadio::vita_udp_rx_impl: ERROR: received an incomplete packet. "
+            << "received " << nbytesRx << " of " << d_buffer.size() << " expected.";
+        d_buffer.resize(0);
+    }
+    return success;
+}
+
+auto vita_udp_rx_impl::process_packet(gr_complex*& outP, int samples_needed) -> int
+{
+    int samples_produced = 0;
+
+    auto hdr = reinterpret_cast<V49_No491_Header*>(d_buffer.data());
+
+    if (d_debug) {
+        auto save_flags = std::cout.flags();
+        auto save_fill = std::cout.fill();
+        std::cout << "**** vita_udp_rx_impl(" << d_src_ip << ":" << d_port
+                  << ")::process_packet() "
+                  << "PACKET/N491 p_i = " << std::hex << std::setw(8) << std::setfill('0')
+                  << hdr->packet_info << "    ****" << std::endl;
+        std::cout.flags(save_flags);
+        std::cout.fill(save_fill);
+    }
+
+    // Dropped packet handling. If the counter doesn't match the expected value, it means
+    // a packet was dropped. Report it, and insert null samples into the output
+    unsigned packet_counter = (hdr->packet_info >> 16) & 0x000F;
+
+    samples_produced += handle_dropped_packet(packet_counter, outP, samples_needed);
+
+    if (samples_produced < samples_needed) {
+        tag_packet(0, samples_produced);
+        samples_produced += process_IQ(outP);
+    }
+
+    return samples_produced;
+}
+
+auto vita_udp_rx_impl::process_v491_packet(gr_complex*& outP) -> int
+{
+    int samples_produced = 0;
+
+    auto hdr = reinterpret_cast<V49_308_Header*>(d_buffer.data());
+    if (d_debug) {
+        auto save_flags = std::cout.flags();
+        auto save_fill = std::cout.fill();
+        std::cout << "**** vita_udp_rx_impl::process_v491_packet()"
+                  << "PACKET/491 p_i = " << std::hex << std::setw(8) << std::setfill('0')
+                  << hdr->packet_info << "    ****" << std::endl;
+        std::cout.flags(save_flags);
+        std::cout.fill(save_fill);
+    }
+
+    tag_v491_packet(0, samples_produced);
+    samples_produced += process_IQ(outP);
+    return samples_produced;
+}
+
+auto vita_udp_rx_impl::handle_dropped_packet(unsigned packet_counter,
+                                             gr_complex*& outP,
+                                             int samples_needed) -> int
+{
+    int samples_produced = 0;
+
+    // assume the first packet isn't dropped :P
+    if (d_first_packet) {
+        d_packetCounter = packet_counter;
+        d_first_packet = false;
+    } else {
+        if (++d_packetCounter != packet_counter) {
+            txStatusMsg();
+
+            // packets were dropped. Insert nulls
+            // (someday, use GR_LOG)
+            std::cout
+                << "gr::CyberRadio::vita_udp_rx_impl: packet loss detected: expected "
+                << d_packetCounter << ", received " << packet_counter << std::endl;
+
+            while (d_packetCounter != packet_counter and
+                   samples_produced < samples_needed) {
+                std::fill_n(outP, d_samples_per_packet, gr_complex(0));
+                samples_produced += d_samples_per_packet;
+                outP += d_samples_per_packet;
+                ++d_packetCounter;
+            }
+        }
+    }
+    return samples_produced;
+}
+
+auto vita_udp_rx_impl::process_IQ(gr_complex*& outP) -> int
+{
+    int samples_produced = 0;
+
+    // Copy IQ data to output
+    // The VITA-49 packet sends I/Q as 16-bit signed quantities. What follows is a bit of
+    // magic. If the data actually comes as Q/I and we want to swap them, do a 32-bit
+    // byteswap (in-place) If we are little-endian and want to swap to host order (and
+    // didn't already swap ??), do a 16-bit swap (in-place)
+    short* IQ = reinterpret_cast<short*>(&d_buffer[d_header_byte_offset]);
+
+    // Swap bytes if requested
+    if (d_swap_iq) {
+        volk_32u_byteswap(reinterpret_cast<uint32_t*>(IQ), d_samples_per_packet);
+    }
+    if (d_swap_bytes xor d_swap_iq) {
+        volk_16u_byteswap(reinterpret_cast<uint16_t*>(IQ), 2 * d_samples_per_packet);
+    }
+
+    // convert the I/Q samples from short to scaled float; copy the
+    // interleaved I/Q floats to the output. In practice, [ (float,float),
+    // (float,float),...] is the same as [complex<float>, complex<float>, ...]
+    volk_16i_s32f_convert_32f(
+        reinterpret_cast<float*>(outP), IQ, 32768.0, 2 * d_samples_per_packet);
+
+    outP += d_samples_per_packet;
+    d_buffer.resize(0); // consume the buffer
+    samples_produced += d_samples_per_packet;
+
+    return samples_produced;
+}
+
+/*******************************************************************************
+ * \brief tag a packet with information from the V49 stream
+ * \param stream which output stream this applies to (should always be 0)
+ * \param offset the relative sample number to attach tags to
+ *******************************************************************************/
+auto vita_udp_rx_impl::tag_packet(int stream, int offset) -> void
+{
+    if (d_tag_packets) {
+        auto hdr = reinterpret_cast<V49_0_Header*>(d_buffer.data());
+
+        uint64_t tag_item = nitems_written(0) + offset;
+
+        // Note if we setup byte swap, it's already been done in place
+
+        // timestamp
+        {
+            auto fractionalTs = uint64_t(0);
+            fractionalTs = uint64_t(hdr->frac_timestamp_msw) << 32;
+            fractionalTs += uint64_t(hdr->frac_timestamp_lsw) & 0x0FFFFFFFFLL;
+            auto tag = pmt::cons(pmt::from_long(hdr->int_timestamp),
+                                 pmt::from_uint64(fractionalTs));
+            add_item_tag(stream, tag_item, pmt::mp("timestamp"), tag);
+        }
+
+        // stream id
+        {
+            auto tag = pmt::from_long(hdr->stream_id);
+            add_item_tag(stream, tag_item, pmt::mp("stream_id"), tag);
+        }
+        {
+            auto tag = pmt::from_long((hdr->ddc_0 >> 28) & 0x0F);
+            add_item_tag(stream, tag_item, pmt::mp("rx_channel"), tag);
+        }
+
+        // frequency
+        {
+            auto tuned_freq = uint16_t((hdr->ddc_0 >> 0) & 0x0FFFF);
+            auto ddc_offset = int32_t((hdr->ddc_1 >> 0) & 0x0FFFFFFFF);
+            {
+                auto tag = pmt::from_long(tuned_freq);
+                add_item_tag(stream, tag_item, pmt::mp("rx_freq"), tag);
+            }
+            {
+                auto tag = pmt::from_long(ddc_offset);
+                add_item_tag(stream, tag_item, pmt::mp("ddc_offset"), tag);
+            }
+        }
+
+        {
+            auto ddc_filter = ((hdr->ddc_2 >> 20) & 0x0FFF);
+            auto tag = pmt::from_float(ndr358_551_ddc_map.at(ddc_filter));
+            add_item_tag(stream, tag_item, pmt::mp("ddc_rate"), tag);
+        }
+
+        {
+            auto tag = pmt::from_long((hdr->ddc_2 >> 0) & 0x0001FFFF);
+            add_item_tag(stream, tag_item, pmt::mp("delay_time"), tag);
+        }
+
+        {
+            auto tag = pmt::from_bool(bool((hdr->ddc_0 >> 27) & 0x01));
+            add_item_tag(stream, tag_item, pmt::mp("delay_en"), tag);
+        }
+
+        {
+            auto ovs = (hdr->ddc_4 >> 28) & 0x0F;
+            std::string ovs_s;
+            switch (ovs) {
+            case 0:
+                ovs_s = "1X";
+                break;
+            case 1:
+                ovs_s = "2X";
+                break;
+            case 2:
+                ovs_s = "4X";
+                break;
+            case 3:
+                ovs_s = "8X";
+                break;
+            case 4:
+                ovs_s = "16X";
+                break;
+            default:
+                ovs_s = std::string("unknown oversample: ") + std::to_string(ovs);
+                break;
+            }
+            auto tag = pmt::mp(ovs_s.c_str());
+            add_item_tag(stream, tag_item, pmt::mp("ddc_ovs"), tag);
+        }
+
+        {
+            auto tag = pmt::from_long((hdr->ddc_4 >> 16) & 0x0FFF);
+            add_item_tag(stream, tag_item, pmt::mp("ddc_agc_gain"), tag);
+        }
+
+        {
+            auto tag = pmt::from_long(((hdr->ddc_4 >> 0) & 0x000007FF));
+            add_item_tag(stream, tag_item, pmt::mp("valid_data_count"), tag);
+        }
+
+        {
+            auto tag = pmt::from_long((hdr->ddc_0 >> 16) & 0x003F);
+            add_item_tag(stream, tag_item, pmt::mp("rx_atten"), tag);
+        }
+    }
+}
+
+/*******************************************************************************
+ * \brief tag a packet with information from the V491 stream
+ * \param stream which output stream this applies to (should always be 0)
+ * \param offset the relative sample number to attach tags to
+ *******************************************************************************/
+auto vita_udp_rx_impl::tag_v491_packet(int stream, int offset) -> void
+{
+    if (d_tag_packets) {
+        uint64_t tag_item = nitems_written(0) + offset;
+
+        // Note if we setup byte swap, it's already been done in place
+
+        auto hdr = reinterpret_cast<V49_308_Header*>(d_buffer.data());
+
+        // timestamp
+        {
+            auto tag = pmt::cons(pmt::from_long(hdr->int_timestamp),
+                                 pmt::from_long(hdr->frac_timestamp_lsw));
+            add_item_tag(stream, tag_item, pmt::mp("timestamp"), tag);
+        }
+
+        // stream id
+        {
+            auto tag = pmt::from_long(hdr->stream_id);
+            add_item_tag(stream, tag_item, pmt::mp("stream_id"), tag);
+        }
+    }
 }
 
 /*******************************************************************************
  * \brief Constructor for vita_udp_rx
- * \param src_ip The Source IP to bind to.
- * \param port Source Port to bind to
- * \param header_byte_offset number of bytes of V49 header
- * \param samples_per_packet number of samples, used to create # of bytes
- * \param bytes_per_packet number of bytes in the total V49 packet. includes trailer.
- * \param swap_bytes equivilent of htonl() uses volk impl.
- * \param swap_iq used for some radios that have I and Q swapped as well as byte_swap
- * \param tag_packets Add aoutput tags to packets
- * \param vector_output Use vector output instead of stream output
- * \param uses_v491 uses VRLP and VEND headers. (308 specific)
- * \param narroband If using a narrowband ddc
- * \param debug output extra info from block
-*******************************************************************************/
-vita_udp_rx_impl::vita_udp_rx_impl(const std::string &src_ip,
-                                   unsigned short port,
-                                   unsigned int header_byte_offset,
-                                   int samples_per_packet, int bytes_per_packet,
-                                   bool swap_bytes, bool swap_iq,
-                                   bool tag_packets, bool vector_output,
-                                   bool uses_v491, bool narrowband, bool debug)
-    : gr::sync_interpolator(
-          "vita_udp_rx", gr::io_signature::make(0, 0, 0),
-          //              gr::io_signature::make(1, 1, sizeof(gr_complex)),
-          //              samples_per_packet),
-          gr::io_signature::make(0, 0, 0), 1),
-      samples_per_packet(samples_per_packet),
-      bytes_per_packet(bytes_per_packet), uses_v491(uses_v491),
-      is_narrowband(narrowband), src_ip(src_ip), port(port),
-      header_byte_offset(header_byte_offset), swap_bytes(swap_bytes),
-      swap_iq(swap_iq), tag_packets(tag_packets), debug(debug),
-      vector_output(vector_output) {
-  if (this->vector_output) {
-    this->set_output_signature(gr::io_signature::make(
-        1, 1, this->samples_per_packet * sizeof(gr_complex)));
-    this->set_interpolation(1);
-  } else {
-    this->set_output_signature(
-        gr::io_signature::make(1, 1, sizeof(gr_complex)));
-    this->set_interpolation(this->samples_per_packet);
-  }
-  // setup the packet counter global.
-  d_packetCounter = -1;
+ * \param cfg The configuration params for this block
+ *******************************************************************************/
+vita_udp_rx_impl::vita_udp_rx_impl(Cfg const& cfg)
+    : Base("vita_udp_rx",
+           gr::io_signature::make(0, 0, 0),
+           gr::io_signature::make(1, 1, sizeof(gr_complex))),
+      d_src_ip(cfg.src_ip),
+      d_port(cfg.port),
+      d_sock(-1),
 
-  // Create input port
-  message_port_register_in(pmt::mp("control"));
-  set_msg_handler(pmt::mp("control"),
-                  boost::bind(&vita_udp_rx_impl::rxControlMsg, this, _1));
+      d_samples_per_packet(cfg.samples_per_packet),
+      d_header_byte_offset(cfg.header_byte_offset),
+      d_bytes_per_packet(cfg.bytes_per_packet),
 
-  // Create output ports
-  message_port_register_out(pmt::mp("status"));
+      d_swap_bytes(cfg.swap_bytes),
+      d_swap_iq(cfg.swap_iq),
+      d_uses_v49_1(cfg.uses_v49_1),
+      d_is_narrowband(cfg.narrowband),
+      d_tag_packets(cfg.tag_packets),
+      d_debug(cfg.debug),
+      d_first_packet(true),
+      d_packetCounter(0),
+      d_buffer(cfg.bytes_per_packet)
+{
+    // don't call work() until there is enough space for a whole packet
+    set_output_multiple(d_samples_per_packet);
 
-  // Create RX Buffer
-  this->buffer = new uint8_t[this->bytes_per_packet];
+    // Create input port
+    message_port_register_in(control_port);
+    set_msg_handler(control_port, boost::bind(&vita_udp_rx_impl::rxControlMsg, this, _1));
+
+    // Create output ports
+    message_port_register_out(status_port);
 }
 
 /*******************************************************************************
  * \brief Recieve a control message. Currntly we just print the rx'd message.
  * \note technically unimplemented.
-*******************************************************************************/
-void vita_udp_rx_impl::rxControlMsg(pmt::pmt_t msg) {
-  std::cout << "****    vita_udp_rx_impl::rxControlMsg    ****" << std::endl;
-  // What did we receive?
-  pmt::pmt_t msgId = pmt::car(msg);
-  pmt::pmt_t content = pmt::cdr(msg);
+ *******************************************************************************/
+void vita_udp_rx_impl::rxControlMsg(pmt::pmt_t msg)
+{
+    std::cout << "****    vita_udp_rx_impl::rxControlMsg: " << msg << "    ****"
+              << std::endl;
+    // What did we receive?
+    pmt::pmt_t msgId = pmt::car(msg);
+    pmt::pmt_t content = pmt::cdr(msg);
 }
 
 /*******************************************************************************
  * \brief Transmit a status message from the block. Currently onlyt tx on
  *        detected packet count errors
-*******************************************************************************/
-void vita_udp_rx_impl::txStatusMsg(void) {
-  //pmt::pmt_t msg = pmt::cons(pmt::intern("status"), pmt::PMT_NIL);
-  pmt::pmt_t msg = pmt::cons(pmt::intern("packet dropped detected"), pmt::PMT_NIL);
-  message_port_pub(pmt::mp("status"), msg);
+ *******************************************************************************/
+void vita_udp_rx_impl::txStatusMsg()
+{
+    auto msg = pmt::cons(pmt::mp("packet dropped detected"), pmt::PMT_NIL);
+    message_port_pub(status_port, msg);
 }
 
 /*******************************************************************************
  * \brief Override of GNURadio start function
  * \return true if socket opened false if error
-*******************************************************************************/
-bool vita_udp_rx_impl::start() {
-  // Init RX Socket
-  std::cout << "Socket opening" << std::endl;
-  this->sock_fd = this->initSocket(); // create recv socket
-  if (this->sock_fd < 0) {
-    perror("Could not create socket.  Check that /proc/sys/net/core/rmem_max "
-           "is set to 268435456");
-    throw "Socket Creation Error";
-  }
-  bool ret = true;
-  return ret;
+ * \todo should this be allowed to throw or should it just return false?
+ *******************************************************************************/
+bool vita_udp_rx_impl::start()
+{
+    auto success = false;
+
+    int sockfd = -1;
+
+    // Create a UDP Socket
+    if ((sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+        raise_error("cannot create socket\n", sockfd);
+    }
+
+    // Set socket to reuse address
+    int enable = 1;
+    if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) < 0) {
+        raise_error("setsockopt SO_REUSEADDR call failed", sockfd);
+    }
+
+    if (not d_is_narrowband) {
+        // /proc/sys/net/core/rmem_max holds this value must be >= recv_buffer_size
+        // linux kernel receiver buffer size. this is not to be confused with the size
+        // of this class' ring buffer.
+        constexpr unsigned long recv_buffer_size = 268435456; // 256 MB
+
+        // Set recv buffer size
+        if (setsockopt(sockfd,
+                       SOL_SOCKET,
+                       SO_RCVBUF,
+                       &recv_buffer_size,
+                       sizeof(recv_buffer_size)) == -1) {
+            raise_error("couldn't set recv buf size.", sockfd);
+        }
+
+        // Verify this sock opt took
+        unsigned long long check_size = 0;
+        unsigned int arg_len = sizeof(check_size);
+        getsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, &check_size, &arg_len);
+        if (check_size != 2 * recv_buffer_size) {
+            std::ostringstream ss;
+            ss << "recv buf size set to " << recv_buffer_size << " but value is "
+               << check_size << "; check max limit in /proc/sys/net/core/rmem_max";
+            ::close(sockfd);
+
+            std::cerr << ss.str() << std::endl;
+            throw std::runtime_error(ss.str());
+        }
+    }
+
+    // Bind the socket
+    sockaddr_in myaddr;
+    memset((char*)&myaddr, 0, sizeof(myaddr));
+    myaddr.sin_family = AF_INET;
+    myaddr.sin_addr.s_addr = inet_addr(d_src_ip.c_str());
+    myaddr.sin_port = htons(d_port);
+
+    if (bind(sockfd, (struct sockaddr*)&myaddr, sizeof(myaddr)) < 0) {
+        raise_error("bind failed", sockfd);
+    }
+
+    d_sock = sockfd;
+    success = true;
+
+    return success;
 }
 
 /*******************************************************************************
  * \brief override for GNURadio stop function from gr::block
  * \return true on exit
-*******************************************************************************/
-bool vita_udp_rx_impl::stop() {
-  std::cout << "Socket closing" << std::endl;
-  close(this->sock_fd);
-  bool ret = true;
-  return ret;
+ *******************************************************************************/
+bool vita_udp_rx_impl::stop()
+{
+    std::cout << "Socket closing" << std::endl;
+    close(d_sock);
+    bool ret = true;
+    return ret;
 }
-
-/*******************************************************************************
- * \brief tag a packet with information from the V49 stream
- * \param index if we rx multiple packets before returning, we need to know how 
- *              to index the tag_offset accordingly.
-*******************************************************************************/
-void vita_udp_rx_impl::tag_packet(int index) {
-  // Load stream offset and current packet header
-  uint64_t tag_offset = nitems_written(0) + (index * this->samples_per_packet);
-  pmt::pmt_t timestamp;
-  pmt::pmt_t stream_id;
-  pmt::pmt_t tuned_freq;
-  // extra ddc tags
-  pmt::pmt_t ddc_offset_freq;
-  pmt::pmt_t ddc_rate;
-  pmt::pmt_t tuner_id;
-  pmt::pmt_t tuner_bw;
-  pmt::pmt_t tuner_atten;
-  pmt::pmt_t delay_en;
-  pmt::pmt_t delay_time;
-  pmt::pmt_t ddc_ovs;
-  pmt::pmt_t ddc_agc_gain;
-  pmt::pmt_t valid_data_count;
-
-  bool extra_tags = false;
-
-  if (this->uses_v491) {
-    V49_308_Header *hdr = (V49_308_Header *)(this->buffer);
-    // Create polymorphic type for timestamp
-    timestamp = pmt::cons(pmt::from_long(hdr->int_timestamp),
-                          pmt::from_long(hdr->frac_timestamp_lsw));
-    // Create polymorphic type for stream id
-    stream_id = pmt::from_long(hdr->stream_id);
-  } else {
-    extra_tags = true;
-    V49_0_Header *hdr = (V49_0_Header *)(this->buffer);
-    // Note if we setup byte swap, it's already been done in place in work()
-    uint64_t fractionalTs = 0;
-    fractionalTs |= ((uint64_t)hdr->frac_timestamp_msw) << 32;
-    fractionalTs |= ((uint64_t)hdr->frac_timestamp_lsw) & 0x00000000FFFFFFFFLL;
-    timestamp = pmt::cons(pmt::from_long(hdr->int_timestamp),
-                          pmt::from_uint64(fractionalTs));
-    // Create polymorphic type for stream id
-    stream_id = pmt::from_long(hdr->stream_id);
-    // get the extra DDC Tags.
-    tuned_freq = pmt::from_long(hdr->ddc_0 & (0xFFFF));
-    uint32_t ddc_filter = ((hdr->ddc_2 & 0xFFF00000) >> 20);
-    ddc_rate = pmt::from_float( ndr358_551_ddc_map.at(ddc_filter) );
-    tuner_id = pmt::from_long(((hdr->ddc_0 & 0xF0000000) >> 28));
-    ddc_offset_freq = pmt::from_long(hdr->ddc_1);
-    delay_time = pmt::from_long( (hdr->ddc_2 & 0x0001FFFF) );
-    delay_en = pmt::from_bool( (bool)((hdr->ddc_0 & 0x08000000) >> 27) );
-    ddc_ovs = pmt::from_long( (hdr->ddc_4 & 0xF0000000) >> 28);
-    ddc_agc_gain = pmt::from_long( (hdr->ddc_4 & 0x0FFF0000) >> 16);
-    valid_data_count = pmt::from_long( (hdr->ddc_4 & 0x000007FF) );
-    tuner_atten = pmt::from_long( (hdr->ddc_0 & 0x003F0000) >> 16);
-  }
-
-  // Hook the tag into the stream
-  add_item_tag(0, tag_offset, pmt::intern("timestamp"), timestamp);
-  add_item_tag(0, tag_offset, pmt::intern("stream_id"), stream_id);
-  if( extra_tags ){
-    add_item_tag(0, tag_offset, pmt::intern("rx_freq"), tuned_freq);
-    add_item_tag(0, tag_offset, pmt::intern("ddc_rate"), ddc_rate);
-    add_item_tag(0, tag_offset, pmt::intern("rx_channel"), tuner_id);
-    add_item_tag(0, tag_offset, pmt::intern("rx_atten"), tuner_atten);
-    add_item_tag(0, tag_offset, pmt::intern("ddc_offset"), ddc_offset_freq);
-    add_item_tag(0, tag_offset, pmt::intern("delay_en"), delay_en);
-    add_item_tag(0, tag_offset, pmt::intern("delay_time"), delay_time);
-    add_item_tag(0, tag_offset, pmt::intern("ddc_ovs"), ddc_ovs);
-    add_item_tag(0, tag_offset, pmt::intern("ddc_agc_gain"), ddc_agc_gain);
-    add_item_tag(0, tag_offset, pmt::intern("valid_data_count"), valid_data_count);
-  }
-}
-
-/*******************************************************************************
- * \brief Initalize the Socket for the udp_rx_impl
- * \return socket else -1 on error
-*******************************************************************************/
-int vita_udp_rx_impl::initSocket() {
-
-  // /proc/sys/net/core/rmem_max holds this value must be >= recv_buffer_size
-  // linux kernel receiver buffer size. this is not to be confused with the size
-  // of this class' ring buffer.
-  unsigned long recv_buffer_size = 268435456; // 256 MB
-
-  int sockfd;
-  struct sockaddr_in myaddr;
-  memset((char *)&myaddr, 0, sizeof(myaddr));
-  myaddr.sin_family = AF_INET;
-  myaddr.sin_addr.s_addr = inet_addr(this->src_ip.c_str());
-  myaddr.sin_port = htons(this->port);
-
-  /* Create a UDP Socket*/
-  if ((sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
-    perror("cannot create socket\n");
-    return -1;
-  }
-
-  /* Set socket to reuse address */
-  int enable = 1;
-  if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) < 0) {
-    perror("setsockopt SO_REUSEADDR call failed");
-    return -1;
-  }
-
-  if (!is_narrowband) {
-    /* Set recv buffer size */
-    if (setsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, &recv_buffer_size,
-                   sizeof(unsigned long long)) == -1) {
-      perror("couldn't set recv buf size.");
-      return -1;
-    }
-    /* Verify this sock opt took */
-    unsigned long long check_size = 0;
-    unsigned int arg_len = sizeof(check_size);
-    getsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, &check_size, &arg_len);
-    if (check_size != 2 * recv_buffer_size) {
-      fprintf(stderr,
-              "ERROR: set recv buf size, but it is incorrect in kernel. check "
-              "max limit in /proc/sys/net/core/rmem_max\n");
-      return -1;
-    }
-  }
-
-  /* Bind the socket */
-  if (bind(sockfd, (struct sockaddr *)&myaddr, sizeof(myaddr)) < 0) {
-    perror("bind failed");
-    return -1;
-  }
-
-  /* Our socket was correctly created */
-  return sockfd;
-}
-
-/*******************************************************************************
- * \brief destroy the data buffer.
- * 
-*******************************************************************************/
-vita_udp_rx_impl::~vita_udp_rx_impl() { delete[] this->buffer; }
 
 /*******************************************************************************
  * \brief GNURadio work function. RX's packets on IP/Port specified.\
- *        and decodes them accodring to configuration. If tagging is enabled
+ *        and decodes them according to configuration. If tagging is enabled
  *        packets are tagged with information.
  * \param noutput_items Number of output items
- * \param input_items Pointer to GNURadio input items
- * \param output_items Pointer to output buffer
+ * \param ninput_items Vector of Number of input items
+ * \param input_items Vector of GNURadio input items
+ * \param output_items Vector of output buffers
  * \return number of output items generated
-*******************************************************************************/
-int vita_udp_rx_impl::work(int noutput_items,
-                           gr_vector_const_void_star &input_items,
-                           gr_vector_void_star &output_items) {
+ *******************************************************************************/
+int vita_udp_rx_impl::general_work(int noutput_items,
+                                   gr_vector_int& ninput_items [[maybe_unused]],
+                                   gr_vector_const_void_star& input_items
+                                   [[maybe_unused]],
+                                   gr_vector_void_star& output_items)
+{
+    auto samples_needed = noutput_items;
+    auto outP = static_cast<gr_complex*>(output_items[0]);
 
-  int noutput = 0;
-  int nbytesRx = 0;
-  // Declare complex output buffer
-  gr_complex *out = (gr_complex *)output_items[0];
-  int numRx = 0;
-  int maxNumRx = 0;
-  if (this->vector_output) {
-    maxNumRx = noutput_items;
-  } else {
-    maxNumRx = noutput_items / this->samples_per_packet;
-  }
-
-  //		while (noutput<=(noutput_items-this->samples_per_packet)) {
-  for (numRx = 0; numRx < maxNumRx; numRx++) {
-    // Recv a packet
-    memset(&pfd, 0, sizeof(pfd));
-    pfd.fd = this->sock_fd;
-    pfd.events = POLLIN | POLLERR;
-    pfd.revents = 0;
-    int poll_res = poll(&pfd, 1, RECV_TIMEOUT);
-
-    if (poll_res > 0) {
-      // We've got some data
-      nbytesRx = recv(this->sock_fd, this->buffer, this->bytes_per_packet, 0);
-      if (nbytesRx == this->bytes_per_packet) {
-        // Byte-swap the header if needed so we can read it
-        if (this->swap_bytes) {
-          volk_32u_byteswap((uint32_t *)(this->buffer),
-                            this->header_byte_offset / 4);
-        }
-        if (this->uses_v491) {
-          V49_308_Header *hdr = (V49_308_Header *)(this->buffer);
-          if (this->debug) {
-            std::cout << "**** vita_udp_rx_impl::work()"
-                      << "PACKET/491 p_i = " << std::hex << std::setw(8)
-                      << std::setfill('0') << hdr->packet_info << "    ****"
-                      << std::endl;
-          }
-        } else {
-          V49_No491_Header *hdr = (V49_No491_Header *)(this->buffer);
-          uint32_t packet_counter = (hdr->packet_info & 0x000F0000) >> 16;
-          if(d_packetCounter == -1){
-            d_packetCounter = packet_counter;
-          } else {
-            if( d_packetCounter == 15 ){
-              if( packet_counter != 0 ){
-                txStatusMsg();
-              }
-            } else {
-              if( packet_counter != (d_packetCounter+1) ){
-                txStatusMsg();
-              }
+    // This method is called because there is room to fill the output buffer. We know
+    // it's at least one packet; wait until the next packet is received
+    while (samples_needed > 0) {
+        // See if we need a new packet
+        if (d_buffer.empty()) {
+            auto success = receive_packet();
+            if (not success) {
+                // This is generally bad and should never happen. Error logging has
+                // already been done, but at this point we don't have anything to work
+                // with. Return what we have and try again?
+                return noutput_items - samples_needed;
             }
-            d_packetCounter = packet_counter;
-          }
-          if (this->debug)
-            std::cout << "**** vita_udp_rx_impl(" << this->src_ip << ","
-                      << this->port << ")::work() "
-                      << "PACKET/N491 p_i = " << std::hex << std::setw(8)
-                      << std::setfill('0') << hdr->packet_info << "    ****"
-                      << std::endl;
-        }
-        // Copy IQ data to output
-        short *IQ = (short *)((uint8_t *)buffer + this->header_byte_offset);
-        // Swap bytes if requested
-        if (this->swap_iq) {
-          volk_32u_byteswap((uint32_t *)(IQ), this->samples_per_packet);
-        }
-        if (this->swap_bytes ^ this->swap_iq) {
-          volk_16u_byteswap((uint16_t *)(IQ), 2 * this->samples_per_packet);
         }
 
-        volk_16i_s32f_convert_32f((float *)(out + noutput), IQ, 32768.0,
-                                  2 * this->samples_per_packet);
-
-        // Tag the incoming packet (ONLY FOR 308 and 651)
-        if (this->tag_packets) {
-          this->tag_packet(numRx);
+        // one packet is in buffer. Process it
+        if (d_uses_v49_1) {
+            samples_needed -= process_v491_packet(outP);
+        } else {
+            samples_needed -= process_packet(outP, samples_needed);
         }
-
-        noutput += this->samples_per_packet;
-        //					break;
-      } else {
-        //					std::cout << "received " << nbytesRx
-        //<< " but expected " << this->bytes_per_packet << std::endl;
-        break;
-      }
-    } else {
-      //				std::cout << "RECV TIMEOUT" <<
-      // std::endl;
-      break;
     }
-  }
 
-  //		std::cout << (this->vector_output?numRx:noutput) << " " <<
-  // noutput_items << std::endl;
-  return this->vector_output ? numRx : noutput;
+    return noutput_items;
 }
-} /* namespace CyberRadio */
-} /* namespace gr */
+} // namespace CyberRadio
+} // namespace gr

--- a/gr-CyberRadio/lib/vita_udp_rx_impl.cc
+++ b/gr-CyberRadio/lib/vita_udp_rx_impl.cc
@@ -217,8 +217,9 @@ auto vita_udp_rx_impl::handle_dropped_packet(unsigned packet_counter,
             while (d_packetCounter != packet_counter and
                    samples_produced < samples_needed) {
                 std::fill_n(outP, d_samples_per_packet, gr_complex(0));
-                samples_produced += d_samples_per_packet;
                 outP += d_samples_per_packet;
+		produce(0, d_samples_per_packet);
+                samples_produced += d_samples_per_packet;
                 ++d_packetCounter;
             }
         }
@@ -252,6 +253,7 @@ auto vita_udp_rx_impl::process_IQ(gr_complex*& outP) -> int
         reinterpret_cast<float*>(outP), IQ, 32768.0, 2 * d_samples_per_packet);
 
     outP += d_samples_per_packet;
+    produce(0, d_samples_per_packet);
     d_buffer.resize(0); // consume the buffer
     samples_produced += d_samples_per_packet;
 
@@ -580,7 +582,7 @@ int vita_udp_rx_impl::general_work(int noutput_items,
         }
     }
 
-    return noutput_items;
+    return WORK_CALLED_PRODUCE;
 }
 } // namespace CyberRadio
 } // namespace gr

--- a/gr-CyberRadio/lib/vita_udp_rx_impl.h
+++ b/gr-CyberRadio/lib/vita_udp_rx_impl.h
@@ -1,4 +1,4 @@
-/* -*- c++ -*- */
+// -*- c++ -*-
 /*
  * Copyright 2017 <+YOU OR YOUR COMPANY+>.
  *
@@ -21,152 +21,67 @@
 #ifndef INCLUDED_CYBERRADIO_VITA_UDP_RX_IMPL_H
 #define INCLUDED_CYBERRADIO_VITA_UDP_RX_IMPL_H
 
-// C Includes
-#include <arpa/inet.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <inttypes.h>
-#include <linux/if_ether.h>
-#include <linux/if_packet.h>
-#include <net/ethernet.h>
-#include <net/if.h>
-#include <netdb.h>
-#include <netinet/in.h>
-#include <netinet/ip.h>
-#include <netinet/udp.h>
-#include <poll.h>
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/mman.h>
-#include <sys/socket.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <sys/un.h>
-#include <unistd.h>
-
-#include <CyberRadio/vita_udp_rx.h>
-#include <volk/volk.h>
-
-#define RECV_TIMEOUT 100
-
-std::map<int, float> ndr358_551_ddc_map = {
-  { 0, 0.25e3},
-  { 1, 0.5e3},
-  { 2, 1.0e3},
-  { 3, 2.0e3},
-  { 4, 4.0e3},
-  { 5, 8.0e3},
-  { 6, 16e3},
-  { 7, 32e3},
-  { 8, 64e3},
-  { 9, 128e3},
-  {10, 200e3},
-  {11, 256e3},
-  {12, 400e3},
-  {13, 1.28e6},
-  {14, 3.2e6},
-  {15, 4e6},
-  {16, 2e6},
-  {32, 8e6},
-  {33, 8e6},
-  {34, 16e6},
-  {35, 16e6},
-  {36, 16e6},
-  {37, 32e6},
-  {38, 32e6},
-  {39, 64e6},
-  {40, 128e6}
-};
-
-// V49 Struct Info
-typedef struct {
-  char p;
-  char l;
-  char r;
-  char v;
-  unsigned int frame_info;
-  unsigned int packet_info;
-  unsigned int stream_id;
-  unsigned int class_id_1;
-  unsigned int class_id_2;
-  unsigned int int_timestamp;
-  unsigned int frac_timestamp_msw;
-  unsigned int frac_timestamp_lsw;
-} V49_308_Header;
-
-// VITA 49 VRT IF data packet header, no class ID
-// (used without external framing on NDR354/364)
-typedef struct {
-  unsigned int packet_info;
-  unsigned int stream_id;
-  unsigned int int_timestamp;
-  unsigned int frac_timestamp_msw;
-  unsigned int frac_timestamp_lsw;
-} V49_No491_Header;
-
-typedef struct {
-  uint32_t packet_info;
-  uint32_t stream_id;
-  uint32_t class_0;
-  uint32_t class_1;
-  uint32_t int_timestamp;
-  uint32_t frac_timestamp_msw;
-  uint32_t frac_timestamp_lsw;
-  uint32_t ddc_0;
-  uint32_t ddc_1;
-  uint32_t ddc_2;
-  uint32_t ddc_3;
-  uint32_t ddc_4;
-} V49_0_Header;
+#include "CyberRadio/vita_udp_rx.h"
+#include <vector>
 
 namespace gr {
 namespace CyberRadio {
 
-class vita_udp_rx_impl : public vita_udp_rx {
-private:
-  // Variables
-  int samples_per_packet;
-  bool swap_bytes, swap_iq;
-  bool vector_output;
-  std::string src_ip;
-  unsigned short port;
-  unsigned int header_byte_offset;
-  unsigned int bytes_per_packet;
-  bool uses_v491, is_narrowband;
-  int sock_fd;
-  bool tag_packets;
-  bool debug;
-  uint8_t *buffer;
-  struct pollfd pfd;
-  int d_packetCounter;
-  bool d_coherent;
+class vita_udp_rx_impl : public vita_udp_rx
+{
+    using Base = vita_udp_rx;
 
-  // Methods
-  void tag_packet(int index);
-  int initSocket();
+private:
+    // Variables
+    std::string const d_src_ip;
+    unsigned short const d_port;
+    int d_sock;
+
+    int const d_samples_per_packet;
+    size_t const d_header_byte_offset;
+    size_t const d_bytes_per_packet;
+    bool const d_swap_bytes;
+    bool const d_swap_iq;
+    bool const d_uses_v49_1;
+    bool const d_is_narrowband;
+    bool const d_tag_packets;
+    bool d_debug;
+    bool d_first_packet;
+    unsigned d_packetCounter : 4;
+
+    std::vector<uint8_t> d_buffer;
+
+protected:
+    // Methods
+    auto receive_packet() -> bool;
+    auto process_packet(gr_complex*& outP, int samples_needed) -> int;
+    auto process_v491_packet(gr_complex*& outP) -> int;
+    auto handle_dropped_packet(unsigned packet_counter,
+                               gr_complex*& outP,
+                               int samples_needed) -> int;
+    auto process_IQ(gr_complex*& outP) -> int;
+
+
+    auto tag_packet(int stream, int offset) -> void;
+    auto tag_v491_packet(int stream, int offset) -> void;
 
 public:
-  vita_udp_rx_impl(const std::string &src_ip, unsigned short port,
-                   unsigned int header_byte_offset, int samples_per_packet,
-                   int bytes_per_packet, bool swap_bytes, bool swap_iq,
-                   bool tag_packets, bool vector_output, bool uses_v491 = true,
-                   bool narrowband = false, bool debug = false);
-  ~vita_udp_rx_impl();
+    vita_udp_rx_impl(Cfg const& cfg);
 
-  void rxControlMsg(pmt::pmt_t msg);
-  void txStatusMsg(void);
+    void rxControlMsg(pmt::pmt_t msg);
+    void txStatusMsg();
 
-  bool start();
-  bool stop();
+    bool start() override;
+    bool stop() override;
 
-  // Where all the action really happens
-  int work(int noutput_items, gr_vector_const_void_star &input_items,
-           gr_vector_void_star &output_items);
+    // Where all the action really happens
+    int general_work(int noutput_items,
+                     gr_vector_int& ninput_items,
+                     gr_vector_const_void_star& input_items,
+                     gr_vector_void_star& output_items) override;
 };
 
 } // namespace CyberRadio
 } // namespace gr
 
-#endif /* INCLUDED_CYBERRADIO_VITA_UDP_RX_IMPL_H */
+#endif // INCLUDED_CYBERRADIO_VITA_UDP_RX_IMPL_H


### PR DESCRIPTION
This change is **not** backwards-compatible. It will break any existing code.

Key aspect of this change is to inherit from `gr::block`. Also the work function (now `general_work`) was updated based on a better understanding of the GNU Radio scheduler. Finally, removed the virtual inheritance from the interface class; this caused a very subtle bug and adds no practical value.

For sources that provide sequence numbers, this change detects dropped packets and inserts null samples to keep the data in alignment. Practically, this should almost never happen, if the kernel is properly tuned with sufficient buffer space. It has been observed near start-up; there may yet be an issue with initialization

I've also observed a reported (tagged) sample rate of 250(!). I don't know where that comes from, but it quickly switches back to a correct sample rate.

I noticed the files I modified don't have a proper copyright statement. You might want to update that?

I added the .clang-format file from GNU Radio, thinking it's reasonable to be consistent with that project. Only my modified files were re-formatted.

I've tested with the NDR-358, and the tags are on the proper packets.
